### PR TITLE
Add The Mad Chronicler to canon

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ subtopics:
 
 * `topic`: describes what aspect of The Drunken Dragon Universe this record describes.
 
+* `contributor`: optionally describes who contributed to the record in the event that a Pull Request is not used.
+
 * `context`: adds the minimum facts the reader or the machine should know to understand the facts contained in this document.
 
 * `facts`: describes the topic. Each fact can be a short sentence or a detailed paragraph that adds depth and detail to the universe.

--- a/records/index.yaml
+++ b/records/index.yaml
@@ -14,3 +14,4 @@ subtopics:
 - import: ./varian-empire
 - import: ./thiolden/thiolden
 - import: ./bestiary/bestiary
+- import: ./user-submitted-stories/library

--- a/records/thiolden/auristar/auristar.yaml
+++ b/records/thiolden/auristar/auristar.yaml
@@ -112,4 +112,22 @@ subtopics:
   needsReview: true
   facts:
   - Protect all of Thiolden through various Adventurers Guild
+
+- topic: Winterbeard's Sigil
+  needsReview: true
+  facts:
+  - The most popular tavern of all Auristar
+  - In the Northern region of Auristar, in the fourth ring
+  import: ./characters/astrid
+  import: ./characters/gadrull
+  import: ./characters/vadanna
+
+- topic: The Mad Chronicler
+  needsReview: true
+  contributor: Marv2.0/ChaosDelivery#2855
+  facts:
+  - Goes by many name amongst the townsfolk
+  - 'Chronicler' is fine by him
+  - Presents himself as a tired old man
+  - Knowledgable about Merfolk
   

--- a/records/thiolden/auristar/characters/astrid.yaml
+++ b/records/thiolden/auristar/characters/astrid.yaml
@@ -1,0 +1,31 @@
+document: astrid/v1
+topic: Astrid, Wintermare, Inn Keeper of Winterbeard's Sigil
+needsReview: true
+context: 
+- Defining Astrid
+subtopics: 
+
+- topic: Race
+  facts: 
+  - Farheim Descendant Human
+
+- topic: Human equivalent age
+  facts: 
+  - 26
+
+- topic: Class
+  facts:
+  - Host
+
+- topic: About Astrid
+  facts:
+  - Hardworking, kind, and obsessed with returning the old glory of the Winterbeard's Sigil. With her new friends Vadanna and Gadrull she is starting to learn that her father's charisma and know-how are not the only ways of running a warm tavern.
+
+- topic: More info
+  facts:
+  - >
+    Owner of the "Winterbeard's Sigil".
+    Alkregg Winterbeard was Astrid's father and was a brilliant host. He provided unique shows and delicious banquets to weary and downcast travelers.
+    Upon his death, the Tavern passed into the hands of his beloved daughter. Without knowing how to generate the same joy as his father.
+    She went through difficult times, with the imminent collapse of her father's legacy, she restructured everything, now she does not seek to be or act like her beloved father, she would follow his path in life and manage the tavern they loved so much.
+    Thanks to this change of thought, Astrid met her current best friend, Vadanna, and old Loogandril.

--- a/records/thiolden/auristar/characters/astrid.yaml
+++ b/records/thiolden/auristar/characters/astrid.yaml
@@ -3,8 +3,8 @@ topic: Astrid, Wintermare, Inn Keeper of Winterbeard's Sigil
 needsReview: true
 context: 
 - Defining Astrid
-subtopics: 
 
+subtopics: 
 - topic: Race
   facts: 
   - Farheim Descendant Human

--- a/records/thiolden/auristar/characters/gadrull.yaml
+++ b/records/thiolden/auristar/characters/gadrull.yaml
@@ -3,8 +3,8 @@ topic: Gadrull, The Culinary Flame
 needsReview: true
 context: 
 - Defining Gadrull
-subtopics: 
 
+subtopics: 
 - topic: Race
   facts: 
   - Firewing Dragonkin

--- a/records/thiolden/auristar/characters/gadrull.yaml
+++ b/records/thiolden/auristar/characters/gadrull.yaml
@@ -1,0 +1,32 @@
+document: gadrull/v1
+topic: Gadrull, The Culinary Flame
+needsReview: true
+context: 
+- Defining Gadrull
+subtopics: 
+
+- topic: Race
+  facts: 
+  - Firewing Dragonkin
+
+- topic: Human equivalent age
+  facts: 
+  - 37
+
+- topic: Class
+  facts:
+  - Cook
+
+- topic: About Gadrull
+  facts:
+  - Master cook and ex-adventurer. His life saved years ago by Astrid the innkeeper of the Winterbeard's Sigil and her friend and tavern maiden Vadanna; now their bestfriend. His knowledge of the exotic flora and fauna of Thiolden gives him an edge on the kitchen.
+
+- topic: More info
+  facts:
+  - >
+    Great cook because his knowledge of flora and fauna of Thiolden.
+    Ex-adventurer.
+    Once saved and cared by Astrid and Vadanna, now his bestfriend.
+    Gadrull was once an adventurer with great magical knowledge. One day on a certain expedition, he was seriously injured, Abandoned by his friends, he ended up in Astrid's tavern, where he was treated and cared for by his owner. After he recovered, he gave his skills to the service of his savior to settle his account but Gadrull never left, finding great friendships with Astrid and Ravanna and showing innate . skill in cooking aided by his knowledge of Thiolden's flora and fauna.
+    Wise and sullen, with little patience but with a lot of passion in his culinary work.
+    In Thiolden, people call "fire" to the cooks of the taverns.

--- a/records/thiolden/auristar/characters/vadanna.yaml
+++ b/records/thiolden/auristar/characters/vadanna.yaml
@@ -2,7 +2,7 @@ document: vadanna/v1
 topic: Vadanna, Joybringer
 needsReview: true
 context: 
-- Defining Gadrull
+- Defining Vadanna
 subtopics: 
 
 - topic: Race

--- a/records/thiolden/auristar/characters/vadanna.yaml
+++ b/records/thiolden/auristar/characters/vadanna.yaml
@@ -1,0 +1,30 @@
+document: vadanna/v1
+topic: Vadanna, Joybringer
+needsReview: true
+context: 
+- Defining Gadrull
+subtopics: 
+
+- topic: Race
+  facts: 
+  - Elf
+
+- topic: Human equivalent age
+  facts: 
+  - 24
+
+- topic: Class
+  facts:
+  - Host
+
+- topic: About Vadanna
+  facts:
+  - Charismatic, talented, and naive, she displays her skills by cheering on and motivating the adventurers of Winterbeard's Sigil. An injury took her away from her career in a big circus. Fate brought her to Astrid and Gadrull. Now they work together with joy and motivation.
+
+- topic: More info
+  facts:
+  - >
+    Belonging to a group of jugglers and trapeze artists in the Auristar circus, Vadanna suffered an injury that diminished his ability and eventually led to his expulsion from the Circus. With no money and no hope, despair washed over her.
+    Finally, Vadanna reached for the Seal of Winterbeard. On his first night, he found Astrid trying to serve beer while waiting tables, preparing food, and trying to make an entertaining scene with juggling. During this chaos, Astrid tripped and knocked over the beers she was carrying to customers, they reacted violently and the music suddenly stopped.
+    Without thinking, Vadanna took a mug full of beer, placed it on her head, and began to dance around the tavern while singing happily, the attention was completely directed to Vadanna, and the attacked customers ended up mesmerized by the songs and movements of Vadanna. Vadanna, They completely forgot about the incident.
+    In the end, the tavern was filled with noise between applause and shouts for the spectacle they had just seen. Thus began the relationship between Astrid and Vadanna, who from that day on began working together on the Sigil of Winterbeard, gradually returning it to its former glory.

--- a/records/user-submitted-stories/dvwl.yaml
+++ b/records/user-submitted-stories/dvwl.yaml
@@ -1,0 +1,98 @@
+document: dvwl/v1
+topic: Short stories by dvwl#3447
+context: 
+- A treasure trove (or garbage dump) of stories by dvwl#3447
+
+subtopics:
+- topic: Aki's day off
+  needsReview: true
+  facts: |
+  Aki, Vilkyr from the East, a proud warrior from a distant land. She had traveled far and wide, battling fierce monsters and vanquishing evil wherever she went. But today was her day off, and she was determined to enjoy it to the fullest.
+  She woke up early, feeling refreshed and rejuvenated. After stretching and practicing her sword techniques for a few hours, she decided to take a stroll through the forest with her animal companion, Fubuki.
+  Fubuki is a <insert animal species here>, with fur as golden as the autumn foliage and eyes that shone like stars. He was Aki's closest ally and trusted friend, always ready to join her on any adventure.
+  As they walked through the forest, Aki couldn't help but feel a sense of joy and wonder. The trees rustled in the gentle breeze, and the sun filtered through the leaves, casting a warm glow over everything. She breathed in the crisp, clean air and felt her spirits lift.
+  After a while, they came to a clearing where a small stream flowed. Aki sat down on a rock and watched as Fubuki sniffed around, exploring the area. She closed her eyes and basked in the peace and quiet of the forest.
+  Suddenly, Fubuki let out a low-pitched growl, and Aki's eyes snapped open. She stood up, hand on her sword, ready for any danger. But as she scanned the area, she saw nothing out of the ordinary.
+  Fubuki trotted over to her and peck her hand, letting out a soft hoot. Aki realized that her companion was simply trying to tell her that it was time to head back.
+  With a smile, Aki patted Fubuki on the head and they set off back through the forest. As they walked, Aki couldn't help but feel grateful for the simple pleasures of life, and the wonderful friends she had made along the way.
+
+- topic: Aztuneio's deeds
+  facts: |
+  Terrorhertz and Vimtyr were sitting by the fire in Winterbeard's Sigil, enjoying a drink and listening to some music. Suddenly, Terrorhertz started telling Vimtyr an exciting story.
+  "Listen up, Vimtyr," he said. "I have a tale to tell you about the great adventurer, Aztuneio, Ally of Beasts. She was a fearless ranger who traveled the land in search of new and exciting quests."
+  Vimtyr leaned forward, his interest piqued. "Tell me more," he said.
+  "Well, one day, Aztuneio heard about a powerful artifact that was hidden deep within a dungeon, guarded by a fierce dragon. She knew that she had to get her hands on that artifact, no matter what the cost," Terrorhertz continued.
+  "But how did she defeat the dragon?" Vimtyr asked.
+  Terrorhertz chuckled. "Ah, that's the best part. Aztuneio didn't defeat the dragon. She befriended it!" he said.
+  Vimtyr looked at Terrorhertz incredulously. "How did she manage that?"
+  "Aztuneio had a way with animals," Terrorhertz explained. "He knew that the dragon wasn't evil, just misunderstood. So, she approached it with respect and kindness, and after a bit of conversation, they became friends. The dragon even helped her get the artifact she was after."
+  Vimtyr shook his head in disbelief. "That's an incredible story," he said. "Aztuneio must have been a truly remarkable adventurer."
+  "She was," Terrorhertz agreed. "And that's why we need more adventurers like her. Brave, kind, and willing to take on any challenge. That's what the Drunken Dragon is all about."
+  As Terrorhertz finished his story, Aztuneio, sitting at a corner just out of their sights, smiled, happy to hear that her deeds were being shared with others. She raised her glass to toast to the beasts of Thiolden and the friendship of the group.
+  As the night went on, more and more adventurers joined the conversation, sharing their own stories of bravery and adventure. Terrorhertz and Vimtyr listened with rapt attention, feeling inspired and energized by the tales of their fellow travelers.
+  In the end, they both knew that they were exactly where they were meant to be - at Winterbeard's Sigil, surrounded by like-minded adventurers, and ready to take on whatever challenge came their way.
+
+- topic: Bodica's herb quest
+  facts: |
+  In the land of Thiolden, there was a great need for new and powerful medicines to heal the sick and injured. The kingdoms had long been at war with neighboring lands and the constant battles had left many wounded and ill. The then leader of Nurmyr, Ude Namvar, who held onto the epithet, Speaker of the Forest, desperate to find a solution, put out a call to all the land's greatest adventurers, scholars, and healers to come forth and aid in the search for new medicinal plants.
+  One such adventurer was a young druid named Bodica. This was from time many moons ago. She had always been fascinated by the healing properties of plants and had spent many years studying the natural world in search of new remedies. When she heard the call of the Ude, she knew that this was her chance to make a real difference and set out on a quest to find the rarest and most powerful plants in all the land.
+  Bodica journeyed deep into the heart of the Virnayen's dense forests, climbing treacherous mountains, and crossing raging rivers in search of her quarry. For many months she traveled, facing countless dangers and overcoming countless obstacles, but she never gave up. Finally, she came upon a hidden valley where she discovered a rare and exotic plant unlike anything she had ever seen before.
+  The plant was tall and green, with delicate purple flowers that seemed to glow in the sunlight. Bodica knew that this was the plant she had been searching for and she carefully harvested a few samples, taking great care to preserve their potency.
+  She brought the samples back to Nurmyr and set to work studying their medicinal properties. She found that the plant had powerful healing properties and could be used to treat everything from minor cuts and bruises to serious wounds and diseases. Ude was overjoyed when he heard the news and ordered that the plant be grown and harvested in large quantities so that it could be distributed to the people of the land.
+  And so, Bodica's quest was a success. Her discovery brought hope to the people of Nurmyr and brought an end to the suffering of many. She was hailed as a hero and her name was remembered in the annals of history as the one who had saved the Nurmyr from certain doom. 
+  Thanks to this act or so the story goes, she unanimously became the leader of Nurmyr. What other acts of unconditional love Bodica performed is a story for next time.
+
+- topic: Eify's legends
+  facts: |
+  Eify, a bard from the bustling city far south who came to the Royal Academy of Oxinton at the School of Arts and Music in Exeter, had always been fascinated by tales of great Vilkyr (Free Sword in the Old Norsund) and their deeds. One night, while enjoying a pint of ale at a local tavern, Eify struck up a conversation with an old traveling bard named Othil. Othil regaled Eify with stories of brave warriors, powerful magi, and cunning thieves, each one more incredible than the last. Eify knew then and there that he had to document and preserve these stories for future generations to enjoy.
+  And so, Eify, having heard songs and read tales of the brave Vilkyr fascinated him to the point of dropping school and becoming one, set out on a journey to far-flung corners of the world, seeking out adventurers who had their own tales of bravery and valor to share. He traveled through dark forests, treacherous mountains, and scorching deserts, always on the lookout for those who had something to add to his collection of stories.
+  Eify met many brave and honorable warriors, each with their own tale of overcoming insurmountable odds to save their people. He also met powerful wizards and warlocks who had harnessed the very forces of nature to defeat their foes. And cunning thieves who had outwitted their enemies and made off with unimaginable treasures.
+  As Eify gathered these stories and shared them with others, he helped to spread the legend of these heroes and inspire others to follow in their footsteps. He became known as the "Darkstar", and his tales were passed down through the generations, becoming a part of the fabric of the world itself.
+  Eify's journey was long and treacherous, but he knew that it was worth it to have been able to preserve these stories for all time. And in the end, Eify knew that he too had become a legend, the bard who had set out to document the stories of great heroes and succeeded. The best songs come from his own "heroic" feats with his own extravagant fashion and performance style.
+
+- topic: Gulnim failed heist
+  facts: |
+  Gulnim sat at his usual table in the dimly lit tavern, nursing a steaming cup of black tea as he waited for his contact to arrive. He was the Black Market Supplier for the Thieves Guild, a shadowy organization that operated in the shadows of the city. His job was to acquire and distribute all manner of illegal goods to the guild's members, from stolen jewels to rare magical artifacts.
+  But today's supply deal had not gone as planned. He had arranged to meet with a wealthy merchant who was rumored to have a collection of rare, enchanted weapons hidden in his private vault. Gulnim had hoped to acquire some of these weapons for the guild, but the merchant had double-crossed him, summoning a group of armed guards to seize the illegal goods and arrest Gulnim and his associates.
+  Gulnim had managed to escape, but he knew that the guild would not be pleased with the outcome of the deal. He would have to report the failure to his superiors and face their anger and disappointment.
+  As he waited for his contact, Gulnim sipped his tea and tried to come up with a plan to make amends for the botched deal. He had a reputation to uphold, and he couldn't afford to let this setback tarnish his name in the criminal underworld.
+  Suddenly, the door to the tea shop swung open and a hooded figure entered, pulling back the hood to reveal a face that was all too familiar to Gulnim. It was the Guild Master of the Thieves Guild, a cunning and ruthless Vulkin known as Vale.
+  "Gulnim," he said, his voice dripping with contempt. "I hear you've had a bit of a setback today."
+  Gulnim nodded, his heart sinking as he realized that Vale had come to confront him about the failed deal. "I'm sorry, Vale," he said, bowing his head in shame. "I'll make it right, I swear."
+  Vale waved his hand dismissively. "There's no time for apologies, Gulnim. I have a job for you, one that will require all of your skills and resourcefulness. A wealthy lord has acquired a valuable magical artifact, and I want it. I need you to retrieve it for me, no matter the cost."
+  Gulnim nodded, knowing that he had no choice but to accept the mission. He was a member of the Thieves Guild, and he had a reputation to uphold. He would have to pull off the heist of his life and bring the artifact back to Vale, or face the consequences.
+  As he listened to Vale's instructions, Gulnim knew that this would be no ordinary job. He would have to use all of his cunning and skill to outwit the lord and his guards, and he would have to be ready for anything.
+  But he was Gulnim, the Black Market Supplier of the Thieves Guild, and he had never backed down from a challenge. He would succeed, or he would die trying.
+  As he finished his tea and prepared to leave, Gulnim knew that this would be a night to remember, a night that would either make or break his reputation in the criminal underworld. But he was ready for whatever lay ahead, and he would not be denied.
+
+- topic: Kilia's new song
+  facts: |
+  Kilia walked into Winterbeard's Sigil, tired from a long day of travel. The tavern was quiet, and she noticed Gadrull, Vadanna, and Astrid sitting together, discussing ways to attract more patrons.
+  As Kilia approached the bar, Vadanna noticed her and said, "Welcome, Kilia. It's been a slow night, but we're hoping to come up with some ideas to bring in more customers."
+  Kilia nodded and smiled, "I might be able to help with that," she said, "I was actually inspired by your conversation, and I've composed a new song for Winterbeard's Sigil."
+  The other three looked at each other in surprise and curiosity. "Let's hear it," Astrid said eagerly.
+  Kilia took a deep breath and began to play her lute. Her voice was clear and strong, filling the quiet tavern with beautiful music.
+  "Come gather 'round all ye travelers near and far
+  To Winterbeard's Sigil, where ale is in a jar
+  The fire's warm, the ale is cool
+  And the stories told are never dull
+  The finest drinks you'll find in the land
+  Served by the kindest of all hands
+  Come drink with us, and stay awhile
+  And share your tales mile after mile"
+  As Kilia finished her song, the group at the bar clapped and cheered, impressed by her beautiful voice and the catchy melody of her song.
+  "That was amazing, Kilia!" Vadanna said excitedly. "We have to add that to our regular repertoire."
+  Kilia smiled, "I'd be happy to play it every time I visit. I think it captures the warmth and hospitality of Winterbeard's Sigil perfectly."
+  And from that night on, every time Kilia visited the tavern, she would sing her song, inviting new patrons to come and experience the hospitality of Winterbeard's Sigil.
+
+- topic: Ulf's artifact
+  facts: |
+  The young and ambitious adventurers (GMA#2763, an Elenidas Elf Fighter and GMA#2913, a Cov Human Cleric), eager for fame and fortune, gathered at Winterbeard's Sigil, a local tavern known for its legendary quests. As they sat at the bar, sipping ale and swapping tales of adventure, a mysterious figure approached them with a proposition.
+  The figure, an aged mage known as Ulf, Magi of the Seven Lights of Auristar, who that very night, somehow managed to sneak away the King's guards that followed him day-in, day-out, for he is the most trusted advisor to the King, offered them a quest to retrieve a valuable and powerful magical artifact known as the "Heart of the Rabbit." The artifact was said to grant immense power and wealth to whoever possessed it, and Ulf was willing to pay a handsome reward for its safe return.
+  Without hesitation, the adventurers accepted the quest and set out on their journey. As they traveled through the rugged mountains and dense forests, they encountered a variety of challenges and dangers. They fought fierce monsters, braved treacherous terrain, and outsmarted rival adventurers who sought the artifact for themselves.
+  But the journey was not without its struggles. The adventurers faced internal conflicts and doubts as they struggled with trust and unity. But through determination and perseverance, they emerged victorious and returned home as heroes.
+  Upon their return, they presented the Heart of the Rabbit to Ulf at the Auristar's Magi Trainhall, who was overjoyed with their success. He bestowed upon them a great sum of gold and treasures, and their names were forever etched into the annals of history as the brave warriors who retrieved the Heart of the Rabbit.
+  The young and ambitious adventurers, now seasoned grandmaster adventurers, set out on new and even more dangerous quests, always seeking to test their limits and prove their worth. 
+  That night, they went back to Winterbeard's Sigil, with a heroes welcome. But they would always remember the journey that made them heroes, and the powerful artifact that started it all, the Heart of the Rabbit.
+  As a final note, the Heart of the Rabbit was not just an ordinary artifact, it was said to contain the soul of a ancient rabbit that was defeated and sealed inside the heart. We all know that rabbits only lived up to 12 human years but this particular one had been around for centuries. The artifact was said to grant immense power to whoever possessed it because it was said to allow the wielder to tap into the rabbit's power and wisdom. It's said that the rabbit's power was so immense that it could grant immortality, control over elemental forces, and even the ability to manipulate aether. The artifact was also said to be highly sought after by powerful wizards, sorcerers, and even kings.
+  What is Ulf up to, you say, is a story for another time.

--- a/records/user-submitted-stories/enkian.yaml
+++ b/records/user-submitted-stories/enkian.yaml
@@ -1,0 +1,52 @@
+document: enkian/v1
+topic: Short stories by Enkian | EGGS World NFT#6314
+context: 
+- A treasure trove (or garbage dump) of stories by Enkian | EGGS World NFT#6314
+
+subtopics:
+- topic: The Bandit and the Baboon
+  facts: |
+  Come with me my friends as we journey north to the isle of Farheim. A land near and dear to many of our hearts. A land filled with wonder, merriment and bitter rivalries. A land that is home to the fabled Drunken Dragon. Founded by the great adventurer Vledic, the Drunken Dragon is a place of camaraderie and respite for heroes and explorers, both old and new alike. 
+  It was a cool Friday evening in early Autumn and many warriors, wizards and friends had gathered in the Drunken Dragon to warm themselves by the hearth with a belly full of the sweetest ale and a meal fit for a king. 
+  Vimtyr, the Whispering Axe, sat at a table by the bar gulping down his second mead of the evening. A quiet fellow, was Vimtyr, but he always enjoyed a tasty mead at the tavern.
+  “That hits the spot,” he said, slamming his tankard onto the wooden table. “Barkeep, a third if you would be so kind.”
+  The bartender sent a beautiful tavern maiden over with the mead, brewed with the finest honey in all of Farheim. It was very famous and Vimtyr’s favourite. His eyes widened as the mead was placed before him. It was a good day indeed.
+  Suddenly, the door of the Drunken Dragon flung open and in walked a hunched figure. He was dressed in fine garments, but his face was as hairy as a monkey...for that was what he was. The figure strode towards the bar, clunking his quarterstaff on the floor with each step. Baboon, as he was known, was once a man, but cursed to take the form of a large monkey by a cunning witch. Baboon believed that the only way to break his curse was to become the richest man in the land. Only then would he be human, once again.
+  “Good evening, ladies and gentlemen,” called out Baboon with a smug smirk. He glanced at Vimtyr, arm outreached and ready to grab his tankard.
+  “I was hoping it would be a peaceful evening, Baboon,” said the Whispering Axe.
+  “I assure you it will be,” chuckled the monkey man as reached the bar, ready to order a drink.
+  The rest of the patrons of the Drunken Dragon were all on edge. When Vimtyr and Baboon were in the same room for longer than an hour, trouble usually brewed up. It is not known who started the rivalry between these two former friends, or acquaintances as I should say, for many tell different versions of the same story. I have my own version, but even I no longer know if it is truth.
+  The evening continued peacefully for some time. Vimtyr quietly chugged his mead, making little conversation. Baboon sat in the corner playing games of chance with fellow patrons, usually coming out on top of the wagers.
+  “Vimtyr, you seem quieter than usual today,” said Baboon, jaunting across the bar on all fours.
+  Vimtyr sighed. “I have no time for your games today. You have made it clear many times that we are not friends, so let us remain strangers.”
+  “I’m here to extend an olive branch,” said Baboon slyly. “Would you care for a drink? Your mead is running low.”
+  Vimtyr raised an eyebrow suspiciously. “If you’re offering, it would be rude of me to turn it down. Thank you, Baboon.”
+  “It is no trouble,” said Baboon as he sauntered off towards the bar.
+  The Whispering Axe sat quietly, unsure of the monkey’s motive. Why was he being so friendly? Vledic would not return until tomorrow, so could it be that Baboon thought that he had free reign to cause mischief? Perhaps, he truly did want to make peace?
+  A tavern maiden approached Vimtyr a short time later with a tankard. Baboon raised his own drink from across the bar, and Vimtyr raised his tankard back. The bandit took a sip of his drink and spat it out immediately.
+  “Wine!” yelled Vimtyr. Never had he been so affronted. “You have caused trouble for the last time, Baboon.”
+  Baboon laughed uproariously, flailing his long limbs about wildly and knocking food and drink to the floor. He only just had time to leap out of the way as a flying axe hurtled towards him and embedded itself in the wall.
+  “Come now, Vimtyr,” he protested. “It was a joke! An aged peach wine for you to enjoy.”
+  Vimtyr was in a rage and could not be reasoned with. He charged across the bar, another axe raised, while Baboon leapt to his feed, using his tail to whip his staff from the floor and into his hand.
+  Vimtyr aimed to cut Baboon’s head clean from his body, but the monkey swiftly parried the strike with his staff.
+  The patrons around the Drunken Dragon cleared the floor. Murmurs about this not being the time and place or what Vledic may think went unheard by Vimtyr and Baboon as they engaged in a ferocious duel.
+  When Vimtyr swung his axe, Baboon would jab him in the stomach. When Baboon would strike at the head, Vimtyr would kick him aside. Tables were tossed across the tavern, bottles were smashed into a thousand tiny fragments, but the fight raged on.
+  The Whispering Axe was hard on the offensive and backed Baboon onto the staircase, but the monkey thrust himself upwards with his staff and grabbed onto the second floor railing with his tail.
+  “You can’t catch me,” grinned Baboon, dangling in front of the still-enraged Vimtyr.
+  The bandit was usually strong-willed enough to resist being egged on, but not today. Vimtyr sprinted up the stairs while Baboon hurled himself onto the rafters, tossing copper coins at Vimtyr.
+  “It was about time I showed you why they called me the Whispering Axe,” muttered Vimtyr, reaching for the axes he carried around his waist.
+  One axe, two axes, three axes, they were flung with might through the air, making a soft whirring sound as they flew. One by one, Baboon dodged, but he started to look truly unnerved for the first time. Each axe was closer than the last, the third cutting a few hairs from the back of Baboon’s neck
+  Sadly for all of us, Baboon could not resist taunting. He turned around, raised his cloak and waved his buttocks at Vimtyr. It was as red as Vimtyr’s face. Baboon scrambled down from the rafters and tossed himself through an open window and onto the roof below.
+  Vimtyr was not to be deterred. He climbed out the window after his foe, and they continued their back-to-back blows. Baboon’s staff was notably shorter than when this fight began, but he would not back down. The patrons gathered outside and watched from the grass below as the rooftop duel only grew evermore wild.
+  The bandit slashed a powerful slash, but Baboon cast it aside and knocked the axe to the ground. Vimtyr reached for another, but he was out. Most of his axes were firmly wedged in the walls of the Drunken Dragon.
+  “Do you yield?” asked Baboon.
+  Vimtyr yelled and charged at the monkey, tackling him off the roof. The pair tumbled through the air and crashed into a heap on the ground, but they would not stop. They punched and kicked, both weaponless, refusing to give into exhaustion, for it was exhausting indeed
+  It was at this point that a bard extraordinaire emerged from the tavern. He was a handsome fellow wearing a blue jacket with a raven perched on his shoulder. He walked down the steps with his guitar raised. You know I’m speaking the truth, particularly the handsome part, because that bard was me.
+  I began to play and a soothing tone spread throughout the air, captivating all who heard it. The melody was mellow, but it filled the area. Everyone from the gathered patrons to the squirrels in the trees listened intently.
+  As my song filled their ears and their hearts, Vimtyr and Baboon fell limply. They finally caved to their exhaustion, but the song rejuvenated them at the same time. The fight was over and peace was returned to the Drunken Dragon.
+  I wish I could tell you that the peace was forever, but even my songs are not that powerful, my friends. Baboon was sent away, not to return until the next day. Vimtyr, however, was approached by Vledic.
+  “Vimtyr, my friend,” said Vledic, “I believe that you have a greater calling than to be involved in petty scraps with Baboon. You have the true heart of a warrior, we have all seen it. Behind that ferocious visage, there is a man who cares for the people. I urge you to travel to Thiolden. It is a land filled with great dangers and there are people there in need of your protection.”
+  “Yes, Vledic,” replied the bandit. “I think that it is time. I shall do as you ask and make for Thiolden.”
+  Vledic smiled. “I am pleased to hear this,” he said, “as the Drunken Dragon grows by the day. I expect you will not be the only adventurer travelling to Thiolden.”
+  Vimtyr nodded. “I have no doubt that many new adventurers from the Drunken Dragon will want somewhere safe to set up their taverns. I will ensure that it is so.”
+  And so Vimtyr began his journey. He travelled south to Thiolden, where nobody knew him, where he could become one with the woods. He was a blank slate here, but it did not take long for the name Whispering Axe to attach itself anew as his blades flung threw the air, slaying beasts aplenty. The only thing to follow him, aside from his name, was a monkey with a staff.

--- a/records/user-submitted-stories/library.yaml
+++ b/records/user-submitted-stories/library.yaml
@@ -1,0 +1,9 @@
+document: library/v1
+topic: User Submitted Short Stories
+context: 
+- A treasure trove (or garbage dump) of stories
+
+- import: ./dvwl
+- import: ./enkian
+- import: ./marv
+- import: ./nurseflamtam

--- a/records/user-submitted-stories/marv.yaml
+++ b/records/user-submitted-stories/marv.yaml
@@ -1,0 +1,50 @@
+document: marv/v1
+topic: Short stories by Marv2.0/ChaosDelivery#2855
+context: 
+- A treasure trove (or garbage dump) of stories by Marv2.0/ChaosDelivery#2855
+
+subtopics:
+- topic: The Mad Chronicler (The Merfolk Tales)
+  facts: |
+  The night was fresh, light was cast onto the street as three figures left the Winterbeard’s Sigil. One tall and slender, the other small but stout and the last one walking on all fours.
+  “Taverns full of tales about the chronicler, Arandel. You sure this maniac can help us decrypt those rune slates?”, the dwarf asked his elven friend.
+  “Far from certain, Thogrim old friend. Though Sorania here thinks it’s a good idea to seek him out regardless. And when has she ever led us astray?”
+  “I still don’t get how you converse with this silver wolf, and she led us astray more times than you’d like to admit. Anyhow, let’s get going and find this man, there is nothing left to do here anyways.” 
+  Thus, our party got going, recounting the strange tales they had heard in the evening. This scholar of madness was an intriguing figure, said to know tales from the ancient of times and modern song alike. Some even whisper that he is a seer as well, dreaming of events that have been, are or are yet to be in his disturbed sleep.1
+  As our trio walked amongst the city the dwarf could be heard laughing heartily.“Ridiculous I say! Corpses I’d understand but toenails?! Which lunatic would take those as payment? Come on Arandel, tell me the lad was drunk when he said it. This must be a sick joke no one would take those!”
+  “Clippings of toenails. And these are the words of Eify. I am afraid to disappoint he was very much sober, said being inebriated would impact his performance. He saw them being traded away behind the tavern, thinks some warlock did buy them, though he does not know the seller. Anyhow What’s the worst you’ve heard tonight my friend?”²
+  “Pfft, nothing can beat that nonsense. There was talk about some potato miracle in a village half a days journey from here.³ Oh ah yes, this black market peddler Vlago, Vlogan, Volggan or somesuch seemed pretty embarrassed. Though I coaxed it out of the poor sod, apparently someone else was looking for our wise man, and well did something rather unspoken of.”
+  “Such as..?”, the elf prompted his companion to go on.
+  “Cutting a dwarf’s beard! Well I bought him a round and told him I wouldn’t utter another word about it. You know common courtesy between people.”
+  “Someone rubbed him behind his ears right?”4
+  “How do you know these things?!”, a shocked Thogrim asked his elven friend.
+  “Thogrim, Thogrim, you forget we are travelling in the company of Sorania.” Arandel said as he patted the wolf’s head.
+  “Oh right… How long have you two been travelling together? And how come you are allowed to do this?”
+  Just as Arandel wanted to answer this question, the three were interrupted by one of the city guard.
+  “What are you looking for here in the second ring at this hour of the night?”
+  “Ah fair lady, we are but simply on a quest to find the chronicler.” Thogrim answered.
+  “The old man? Just don’t carry any open flame into his abode. Why do you seek him out?”
+  “Oh well you see, there is this rune slate we found, and we hope he might be able to decipher it for us. The tongue is old and we could only make out a few words myself. You see this…” the dwarf started to explain as he was cut off by guard. “I’ll have you know that rune magic is forbidden in this city! Explain yourself at once!”
+  “My lady, what my companion here wanted to say, is that the slate is not magical, the runes are just the written word of the people alive at that time. We heard the chronicler mumble something about saltwater granting strength and power, so we thought he might be able to read the merfolk tongue. At the very least he will be interested in studying it.” Arandel interjected.
+  “That old story. I must inform you ingesting saltwater does not grant you any strength or power at all, at best you start puking your guts out. Forgive my harshness, it’s just we had some terrible experience with rune magic and thus it was forbidden.”5
+  “Let me guess, some fool caused a cataclysmic explosion of power putting them too close to each other to safe on magical infused material or? Tsk. beginner mistakes, let me tell you rune magic is a dangerous craft for those not understanding the forces involved. It’s better you humans leave it alone, the consequences are not worth the benefits” the dwarf replied.
+  “What do you know of rune magic?!” the knight demanded answer of Thogrim.
+  “Me personally, little at all, I know that our ancestors were well versed in it, built cities underneath mountains we are unable to replicate. There are others more knowledgeable in this craft, I just know that the novice better have a good master else, he spells his own doom. You see I am soldier first and merchant second, I ain’t no runesmith. Never had the brains to understand half the arcane formulae required to even infuse my first one. But coin, that I do understand.”
+  “I see, well in this case pray continue on your quest, or do you need help finding the chroniclers dwelling?”
+  “We would be delighted to be travelling in your company. Pray forgive me, but I did not catch your name before fair lady.” Arandel sought to reconcile with the guard.
+  “Marendil. It is not far, let me show you the way.”
+  And so the search continued, along the way they talked about a plethora of topics, the past adventures of Arandel and Thogrim, the life in Auristar, history and much more.
+  It was not long before our heroes approached an old house nearby an illuminated pond. Without hesitation Marendil opened the squeaking door and lead our party inside.
+  There they found rooms filled with shelfs and other storage filled to the brim with scrolls, parchments, books and other written works. Even the one or the other stone slate poked through this chaotic collection. At the end of this maze of knowledge, in a quaint little study they found the person they were looking for. Slumped over his desk, there he was. The Chronicler.
+  “Welcome in my humble abode, how may I help you?” a tired old man asked the adventurers.
+  “Mr. Chronicler I bring before you, Thogrim, Arandel and this here silver wolf I think they said is called Sorania.” Marendil introduced the party.
+  “A silver wolf? Marendil consider yourself lucky, they have been extinct in Thiolden for many aeons now. I heard stories that some elven folk had silver wolf cavalry, though I never dared dream to see one myself. They are loyal and intelligent companions. So I take it you come from far away Thogrim and Arandel.”
+  “Yes Mr. Chronicler was it? I thought you would have a name.” Arandel responded.
+  “I have plenty of names amongst the townsfolk, but Chronicler should do fine for now. Tell me one does not travel from outside Thiolden to Auristar just to see the world. Why have you come here?”
+  “Well actually he does” Thogrim replied, “Arandel is known as the wandering scholar, striving to learn as much from the world as he can. However, you are right, we did not venture forth simply on a mere quest for knowledge. We heard of a wise man, versed in the different tongue of empires long forgotten, we followed the stories and the closer to Thiolden we got the more numerous the rumours got.”
+  As Thogrim recounted the tales of their journey, Arandel unpacked the rune slate and placed it on the desk. The eyes of the chronicler widened…
+  “Impossible, it can not be. Merfolk runes.” he exhaled “Where did you get this from? Do you know where they live now or what happened to them?”
+  “Thogrim found this amongst his family heirlooms. We do not, we thought maybe you could help us decipher, the little I could make out leads me to believe, that should they still exist this slate here would point us to were they last set up residence.” the elf explained.
+  “By the lights! This is most interesting news, all I know is a story about some people that drank the water of the sea before castings powerful magic, as if commanding the elements themselves. Could it be?..”
+  “That sounds like old folktales I have heard. Do you know something about a siren’s song? It is said that merfolk song could conjure up realities of different kind. To guide home lost sailors or sink threats to their homes.” Arandel remarked.
+  This seemed to remind the chronicler of something. “Excuse me, but would you be up for another adventure? You see there is this story about an old merfolk relic, I have an idea were it may lay buried. Alas my bones are old, my heart is weary, so I wonder if instead of me you three could go?”

--- a/records/user-submitted-stories/nurseflamtam.yaml
+++ b/records/user-submitted-stories/nurseflamtam.yaml
@@ -1,0 +1,188 @@
+document: nurseflamtam/v1
+topic: Short stories by Nurseflamtam#8192
+context: 
+- A treasure trove (or garbage dump) of stories by Nurseflamtam#8192
+
+subtopics:
+- topic: Thiolden and The Cursed Blade (part 1)
+  facts: |
+  Auristar Abbelka was a young vulkin who lived in the peaceful village of Thiolden. She was a skilled artist, known for her delicate and intricate prints. However, in Thiolden, it was strictly forbidden to create prints that depicted negative will or negative emotions.
+  One day, a group of Kullmyr, a race of powerful and malevolent creatures, came to Thiolden in search of a skilled artist. They had heard of Auristar's talent and wanted her to create a print that would spread negative will throughout the village.
+  Auristar, knowing the dangers of such a task, refused to comply. She knew that the Kullmyr were notorious for causing destruction and chaos wherever they went, and she didn't want to be a part of it.
+  Despite her refusal, the Kullmyr persisted and began to threaten the safety of Auristar and her loved ones. Determined to protect her village and her family, Auristar made the difficult decision to flee into the magical forest that surrounded Thiolden.
+  As she wandered deeper into the forest, Auristar encountered all sorts of strange and wondrous creatures. She met talking animals, glowing flowers, and even a group of friendly sprites.
+  But the forest also held its dangers. Auristar encountered vicious beasts and dangerous predators, and she knew she had to be careful. As she continued on her journey, she began to feel lost and alone, wondering if she would ever find her way back home.
+  Just when all hope seemed lost, Auristar stumbled upon a small child who was being attacked by a group of monsters. Without hesitation, Auristar used her quick thinking and artistic skills to distract the monsters and lead the child to safety.
+  The child, who was lost and separated from her family, was grateful to Auristar for rescuing her. Together, they journeyed through the forest, facing challenges and making new friends along the way.
+  Finally, after many days of traveling, Auristar and the child reached the edge of the forest and made their way back to Thiolden. The village was overjoyed to see Auristar safely returned, and the child was reunited with her family.
+  From that day on, Auristar became known as a hero in Thiolden, and she continued to create beautiful and positive prints that brought joy and hope to the people of her village. And although she still sometimes thought of the magical forest and the adventures she had there, she knew that she had made the right decision in protecting her home and the people she loved.
+
+- topic: Thiolden and The Cursed Blade (part 2)
+  facts: |
+  Eify: I can't believe you would do that without even consulting me first.
+  Aumara: (sighs) I know. I'm sorry. But I was desperate.
+  Eify: Desperate for what?  
+  Aumara: (pauses, then speaks slowly) We've been working on this venture for years, and we're finally at a point where we can really make it take off. But we're still missing one key ingredient.
+  Eify: (frowns) What are you talking about? 
+  Aumara: (takes a deep breath) We need funding. A lot of it. And I know a guy named Gulnim who can help us get it. But he's got a lot of connections, and he's not easy to impress.
+  Eify: (narrows his eyes) And you thought using our daughter to get his attention was the best way to do it?
+  Aumara: (hesitates) It was the only way I could think of. I thought if he saw what a great family we are, he might be more likely to invest in us.
+  Eify: (stands up and starts pacing) You can't just use our daughter like that. She's not some pawn to be manipulated.
+  Aumara: (stands up, facing Eify) I know. And I'm sorry. But it's not like I'm asking her to do anything dangerous. Just show up at a few guild events. 
+  Eify: (shakes his head) I can't believe you would even consider something like this. And who is this Gulnim guy?
+  Aumara: (hesitates) He's a black market supplier for the Thieves Guild. He has a lot of connections and can get us the funding we need, but he's not exactly the most reputable person.
+  Eify: (looks skeptical) And you think he's our best option?
+  Aumara: (nods) It's not ideal, I know. But we've exhausted all of our other options. This is our last chance to get the funding we need.
+  Eify: (pauses, then speaks slowly) I don't like it. But I guess I understand where you're coming from.
+  Aumara: (relieved) Thank you. I promise, I'll do everything I can to make sure our daughter is safe. 
+  Eify: (nods) I hope so. Because if anything happens to her, I'll never forgive you.
+  (The scene ends as Eify and Aumara stand facing each other, both looking uncertain and tense.)
+
+- topic: Thiolden and The Cursed Blade (part 3)
+  facts: |
+  Aumara sat at a table in the corner of the Drunken Dragon inn, staring at the piece of parchment in front of her. Eify stood across from her, his arms crossed and a scowl on his face.
+  "How could you do this behind my back?" Eify said, his voice laced with anger. "You know how I feel about the black market."
+  "I had to do something," Aumara replied, her voice calm but determined. "We've been getting more and more travellers coming through here, and with the increase in attacks from those creatures in the woods, we need to beef up our security to protect them. Gulnim was the only one who would lend us the money for hired help."
+  Eify let out a frustrated sigh. "And what happens if we can't pay him back? You know how he operates. He'll ruin us."
+  Aumara looked up at Eify, her eyes steady. "I'll make sure we can pay him back. And if we can't, I'll take responsibility for it. I won't let him hurt you or the inn. But more importantly, I won't let those creatures kill any more innocent travellers."
+  There was a moment of silence as the two of them stared at each other, neither one backing down. Finally, Eify let out a sigh and sat down at the table.
+  "Fine," he said. "But I'm coming with you when you meet with Gulnim. I want to hear his terms for myself."
+  Aumara nodded and stood up, gathering the parchment and tucking it into her pocket. "I'll go find him now. Meet me at the entrance in an hour."
+  Eify watched as Aumara left the inn, his mind racing with worry. He knew he couldn't stop her from going through with this, but he couldn't shake the feeling that something was going to go wrong.
+  An hour later, Eify met Aumara at the entrance of the inn as promised. Together, they walked to the seedy part of town where Gulnim did most of his business.
+  As they approached the door of a dingy storefront, Eify's nerves began to get the better of him. He turned to Aumara, his voice shaking slightly.
+  "Are you sure about this?" he asked.
+  Aumara gave him a reassuring smile. "I'm sure. Let's go see what Gulnim has to say."
+  They walked into the storefront and were greeted by a thick cloud of smoke and the sound of laughter. In the corner, they saw Gulnim sitting at a table, surrounded by a group of rough-looking men.
+  Aumara approached the table and cleared her throat, drawing Gulnim's attention.
+  "Ah, Aumara," Gulnim said with a smile. "I was wondering when you'd come to see me. And who is this?" he asked, nodding towards Eify.
+  "This is Eify," Aumara replied. "He's a partner in the inn."
+  Gulnim chuckled. "Well, Eify, it seems you have quite the enterprising partner here. She's come to me with a proposition. Are you interested in hearing the terms?"
+  Eify nodded, his mouth feeling dry. He knew this was the moment he had been dreading.
+  Gulnim leaned back in his chair, a sly grin on his face. "The terms are simple. You pay me back
+  Gulnim leaned back in his chair, a sly grin on his face. "The terms are simple. You pay me back the amount we agree upon, plus a generous interest fee, on the agreed upon date. Fail to do so, and I'll have to take drastic measures to recoup my investment. Do we have a deal?"
+  Eify and Aumara exchanged a worried glance. They knew they had no choice but to agree to Gulnim's terms, but they also knew they couldn't afford to pay back the loan on time.
+  Just as Eify was about to speak, Gulnim added a caveat to the deal.
+  "Of course, there is one other thing I require," he said, his tone suggestive. "I've heard about your daughter's talents. I think she could be of great use to me in my business dealings."
+  Aumara's eyes narrowed. "What are you suggesting?" she asked, her voice cold.
+  Gulnim chuckled. "I'm just suggesting that if you can't pay me back on time, you could use your daughter's talents to make up the difference. It's a win-win situation for all of us."
+  Eify felt his blood boil. He couldn't believe what he was hearing.
+  "You can't be serious," he said, his voice shaking with anger. "We won't use our daughter like that."
+  Gulnim shrugged. "Suit yourself. But if you can't pay me back on time, that's the only option you'll have."
+  Eify and Aumara glared at Gulnim, their minds racing with fear and anger. They knew they were in a difficult position, and they didn't know what they were going to do.
+  As they stood there, they noticed movement in the background. A few of Gulnim's men had shifted in their seats, their hands hovering near their weapons. It was a clear warning that if Eify and Aumara made an issue of things, there could be consequences.
+  With heavy hearts, Eify and Aumara left the storefront and made their way back to the inn. They knew they had a difficult decision to make. They could try to come up with the money on their own and risk everything, or they could agree to Gulnim's terms and risk their daughter's safety. Either way, they knew they were in for a rough ride.
+  Eify and Aumara glared at Gulnim, their minds racing with fear and anger. 
+  Just as they were about to speak, Gulnim called them over to his table. He stood up from his seat and gestured for them to come closer.
+  "I know this is a difficult situation," Gulnim said, his voice surprisingly compassionate. "But I promise you, I'll be fair. I just need to make sure my investment is secure. Do we have a deal?"
+  Eify and Aumara nodded their heads in resignation, and Gulnim grinned triumphantly.
+  "I knew you'd see reason," he said. "I'll have my man draw up the contract. You'll have it by tomorrow morning."
+  Eify and Aumara followed Gulnim out of the storefront, their hearts heavy with dread. As they left, Gulnim saw them out personally, making sure to shake their hands and assure them that everything would work out.
+  As they rode home along the bridle path that snakes through the valley, Eify and Aumara were lost in thought. They knew they were in a terrible situation, and they didn't know how they were going to get out of it. They didn’t see the dark rider close in from the adjoining path, nor the archers in the trees up ahead. 
+
+- topic: Thiolden and The Cursed Blade (part 4)
+  facts: |
+  As they rode home along the bridle path that snakes through the valley, Eify and Aumara were lost in thought. They knew they were in a terrible situation, and they didn't know how they were going to get out of it. They didn’t see the dark rider close in from the adjoining path, nor the archers in the trees up ahead. What happened next?
+  Write a scenario where they suddenly become aware of the hidden soldiers but are relieved to see they are friends. 
+  As Eify and Aumara rode home along the bridle path that snakes through the valley, they were lost in thought, unaware of the danger that lurked ahead. Suddenly, they heard the sound of hoofbeats approaching from the adjoining path. Eify's heart raced as he turned to see a dark rider closing in on them.
+  Just as they were about to panic, they realized that the rider was a friend - their neighbor, Taren, who was accompanied by a group of archers from the village. Eify and Aumara breathed a sigh of relief as Taren explained that he had been sent to find them and bring them back to the safety of the village.
+  "We've been worried sick about you two," Taren said as he dismounted from his horse. "There have been rumors of bandits and other dangers in these parts, and we didn't want you to be caught off guard."
+  Eify and Aumara thanked Taren and the archers for their concern and protection, and they rode back to the village together, grateful for the timely intervention of their friends.
+  Taren brings news that Aumaras father is sick and they must find a witch doctor immediately. This would mean taking a detour past Dark Rock Culverin, so named after the battle fought there leaving hundreds of cannons strewn across the plan. 
+
+- topic: Thiolden and The Cursed Blade (part 5)
+  facts: |
+  Taren: Eify, Aumara, I'm sorry to bring more bad news, but I just received word that there is an emergency at the Inn. There is an imminent threat from bandits and the Innkeeper is relying on your help.
+  Eify: Damn. We can't leave the Inn unprotected. Aumara, you go and find the witch doctor. I'll go and deal with the threat at the Inn.
+  Aumara: Are you sure, Eify? It's not safe for you to go alone.
+  Eify: I know, but I don't have a choice. The Innkeeper is counting on us. You go and find the witch doctor. I'll meet you back here as soon as I can.
+  Aumara: Once the threat is dispelled, albeit temporarily have word put out that help is needed at the Drunken Dragon.
+  Eify opened his mouth to protest but was cut off 
+  Aumara: All right, Eify. Be careful. I'll see what I can do to find the witch doctor and meet you back here as soon as I have any news. 
+  Sensing that the financial burden of this request weighed on Eify, Aumara added ‘Don’t worry about the money, safety and health first’/
+  Eify nodded.
+  Aumara: Meet two days hence and then we can make flight with the witch doctor and help father. 
+  With that they parted ways, Eify with Taren and two men, Aumara by herself, white horse belly and flank dark with mud.
+
+- topic: Thiolden and The Cursed Blade (part 6)
+  facts: |
+  Eify and Taren rode their horses as fast as they could towards the Drunken Dragon, determined to protect their home from raiders. They had left Aumara to seek the help of the witchdoctor Jkaeri in Dark Rock Culverin, but they had no way of knowing what dangers she might be facing.
+  As they approached the tavern, they could see that it was eerily quiet. No sounds of fighting or shouting could be heard. Eify and Taren exchanged a worried look, their sense of foreboding growing stronger.
+  They dismounted their horses and cautiously approached the entrance of the Tavern. Taren pushed open the door, his hand on the hilt of his sword. Inside, the scene was chaotic. Tables and chairs were overturned, and the floor was covered in broken glass and spilled ale. But there was no sign of any raiders.
+  Eify let out a low curse. "Where are they?" he muttered.
+  Suddenly, a loud crash came from the back room. Eify and Taren looked at each other, then drew their swords and rushed towards the sound. As they burst into the room, they saw nothing but empty space.
+  Eify swore again. "We've been tricked," he said. "There was never any threat here. We were meant to be away from the crossroads."
+  Taren nodded, his face grim. "We have to go back and find Aumara. She might be in danger."
+  The two friends quickly left the tavern and mounted their horses, racing back towards the crossroads. 
+  Eify and Taren approached the crossroads cautiously, their eyes scanning the ground for any signs of their quarry. Taren pointed to a set of horse tracks that led off to the left.
+  "Look, those tracks are fresh," he said. "And see how they're joined by others? I think we're on the right track."
+  Eify nodded, her heart racing with excitement and a hint of fear. They followed the tracks with stealth, moving as quietly as possible through the underbrush.
+  Eify and Taren stood over the evidence of the recent ambush, their eyes scanning the ground for any clues as to who could have attacked their friend, Aumara. The assassins had dismounted in the nearby woods, using the treeline to obscure their approach.
+  The two friends knew they had to find out who was responsible for this attack. They followed the tracks, their footsteps sinking into the muddy ground as they made their way through the green yet barren lands.
+  As they walked, the tension between them grew. They both knew that whoever was responsible for this attack was still out there, somewhere in these desolate marshes.
+  The tracks led them to a clearing, where they found two of the assassins, lying dead on the ground. It was clear that they had been killed by someone, but who could have done this? Eify and Taren searched the area, but found no sign of the killer.
+  They continued on, their eyes peeled for any sign of the remaining assassins. The tracks led them deeper into the marshes, the murky water swallowing their feet as they trudged forward.
+  The air was heavy with the smell of decay, and the only sound was the squelching of their footsteps in the mud. It was a haunting, eerie place, and Eify and Taren couldn't shake the feeling that they were being watched.
+  As they pressed on, they saw the tracks split off in two different directions. Eify and Taren looked at each other, unsure of which way to go.
+  "We have to split up," Eify said, her voice barely above a whisper. "We'll cover more ground that way."
+  Taren nodded, and the two friends set off in opposite directions, each following their own set of tracks.
+  As they walked, the marshes seemed to close in around them, the thick brush and overgrown trees blocking out any sign of the outside world. Eify and Taren were completely alone, with only their determination to find the truth driving them forward.
+  But as the hours passed, their hope began to fade. They had found no sign of the remaining assassins, and the tracks had long since disappeared into the muddy waters.
+  Exhausted and disheartened, Eify and Taren made their way back to the clearing where they had found the dead assassins. They had failed in their mission, and they knew that Aumara would never be safe until the perpetrators were brought to justice.
+  But they also knew that they couldn't give up. They would have to find a way to continue their search, no matter how difficult or dangerous it may be. For Aumara, and for all those who had fallen victim to the shadowy forces that lurked in these green yet barren lands.
+
+- topic: Thiolden and The Cursed Blade (part 7)
+  facts: |
+  Eify and Taren stood over the evidence of the recent ambush, their eyes scanning the ground for any clues as to who could have attacked their friend, Aumara. The assassins had dismounted in the nearby woods, using the treeline to obscure their approach.
+  The two friends knew they had to find out who was responsible for this attack. They followed the tracks, their footsteps sinking into the muddy ground as they made their way through the green yet barren lands.
+  As they walked, the tension between them grew. They both knew that whoever was responsible for this attack was still out there, somewhere in these desolate marshes.
+  The tracks led them to a clearing, where they found two of the assassins, lying dead on the ground. It was clear that they had been killed by someone, but who could have done this? Eify and Taren searched the area, but found no sign of the killer.
+  They continued on, their eyes peeled for any sign of the remaining assassins. The tracks led them deeper into the marshes, the murky water swallowing their feet as they trudged forward.
+  The air was heavy with the smell of decay, and the only sound was the squelching of their footsteps in the mud. It was a haunting, eerie place, and Eify and Taren couldn't shake the feeling that they were being watched.
+  As they pressed on, they saw the tracks split off in two different directions. Eify and Taren looked at each other, unsure of which way to go.
+  "We have to split up," Eify said, her voice barely above a whisper. "We'll cover more ground that way."
+  Taren nodded, and the two friends set off in opposite directions, each following their own set of tracks.
+  As they walked, the marshes seemed to close in around them, the thick brush and overgrown trees blocking out any sign of the outside world. Eify and Taren were completely alone, with only their determination to find the truth driving them forward.
+  But as the hours passed, their hope began to fade. They had found no sign of the remaining assassins, and the tracks had long since disappeared into the muddy waters.
+  Exhausted and disheartened, Eify and Taren made their way back to the clearing where they had found the dead assassins. They had failed in their mission, and they knew that Aumara would never be safe until the perpetrators were brought to justice.
+  But they also knew that they couldn't give up. They would have to find a way to continue their search, no matter how difficult or dangerous it may be. For Aumara, and for all those who had fallen victim to the shadowy forces that lurked in these green yet barren lands.
+
+- topic: Thiolden and The Cursed Blade (part 8)
+  facts: |
+  As they drew closer, they began to see more signs that they were on the right path. The tracks became more numerous, and they could see the occasional broken twig or crushed blade of grass.
+  "We must be getting close," Eify whispered. "I can feel it."
+  Taren nodded, his hand straying to the hilt of his sword. They continued to follow the tracks, their senses heightened as they crept closer to their quarry.
+  Finally, they saw movement up ahead. A group of horses and riders emerged from the trees, led by a tall, regal woman with long, flowing hair.
+  "Aumara," Eify whispered, a sense of awe and determination in her voice. "We've found her."
+  Taren nodded, his grip on his sword tightening. They followed Aumara and her riders with stealth, ready to strike at a moment's notice. The tension was thick in the air as they approached the crossroads, unsure of what awaited them.
+  Finally, in the distance, they saw a scene of struggle. It was hard to make out what was happening, but it was clear that Aumara was in trouble.
+  Eify and Taren hesitated for a moment, wondering what to do. Then, Taren had an idea. "The trader!" he exclaimed. "He might know something about what's going on. We should go talk to him."
+  Eify nodded, and the two friends set off towards the trader's camp. As they approached, they saw that the trader was involved in the struggle, fighting alongside Aumara.
+  Together, Eify, Taren, and the trader were able to defeat the attackers and rescue Aumara. As they stumbled away from the scene, bruised and battered, they knew that they had narrowly avoided disaster.
+  "We have to get out of here," Taren panted, his chest heaving. "We don't know who set us up or why, but we can't stay in one place for long."
+  Eify nodded, his face grim. "We'll figure out what happened and make those responsible pay," he vowed.
+  And with that, the four friends set off into the night, ready to face whatever dangers lay ahead.
+
+- topic: Thiolden and The Cursed Blade (part 9)
+  facts: |
+  Eify and Tanem trudged through the wetland, the sun beating down on their backs as they searched for any sign of Aumara. They had seen the struggle, the telltale signs of a fight, but their friend had vanished into the swampy wilderness. They knew that two of the assassins were already dead, but one was still missing, and they feared that Aumara had fallen victim to the last remaining killer.
+  Despite the discomfort of their makeshift camps at night, a small tarp stretched over their heads to provide some shelter from the elements, they pressed on. They were determined to find Aumara, or at least discover her fate.
+  As they neared the mountains, they began to come across the remains of the assassins' camp. It was clear that they were on the right track. The evidence of the killers' presence was all around them, and they knew that they were getting closer to their quarry.
+  Despite their determination, the search was not easy. The wetlands were treacherous, with hidden bogs and swamps that could swallow a person whole. Eify and Tanem had to be constantly on guard, their eyes and ears alert for any sign of danger.
+  As the days passed, they grew more and more tense. They knew that the assassin was still out there, somewhere, and they feared that he might be tracking them as well. They kept their weapons close at hand, ready for any attack that might come.
+  Finally, after what seemed like an eternity, they caught sight of the assassin. He was crouched behind a tree, his eyes fixed on them as they approached. Eify and Tanem drew their weapons, their hearts racing with fear and excitement.
+  The assassin sprang from his hiding place, a snarl on his lips and a blade in his hand. Eify and Tanem met him head-on, their swords clashing in a shower of sparks. The fight was fierce and intense, the three of them locked in a deadly dance of steel.
+  Eify and Tanem were skilled warriors, but the assassin was no slouch either. He fought with all the ferocity of a cornered animal, striking out at them with brutal efficiency. The battle raged on, each of them giving it their all, until at last the assassin stumbled and fell to the ground under a crushing blow from Eify.
+  Eify and Tanem approached the fallen assassin cautiously, their swords still at the ready. He was wounded, his breathing labored, but they knew that they couldn't let their guard down just yet.
+  "We have to take him alive," Eify said through gritted teeth. "He knows where Aumara is. We have to find out where she is and make sure she's safe."
+  Tanem nodded, his face grim. They both knew that this wouldn't be easy. The assassin was a dangerous man, and he wouldn't give up his secrets easily.
+  But they were determined to find Aumara, no matter what it took.
+  Eify knelt down beside the assassin, his sword pointed at the man's chest. "Where is Aumara?" he demanded. "What have you done with her?"
+  The assassin sneered up at him, his eyes cold and calculating. "I'll never tell you," he spat. "You might as well kill me now."
+  Eify's grip tightened on his sword. "We're not going to kill you," he said, his voice low and menacing. "But we will do whatever it takes to find Aumara. So you better start talking, or things are going to get very unpleasant for you."
+  The assassin looked at him for a moment, then let out a sigh. "Fine," he said. "I'll tell you where she is. But you're not going to like it."
+  Eify leaned in closer, his ears perked up. "Tell us," he said. "Where is Aumara?"
+  "She's in the mountains," the assassin said. "In the hands of Mili, Soul Butcher and his minions. They've been using her as bait to lure you out into the open."
+  Eify and Tanem exchanged a glance, their hearts sinking. They had known that the stakes were high, but they had never expected this.
+  "We have to go after her," Tanem said, his voice grim. "We can't let her fall into the hands of the The Butcher."
+  Eify nodded, his determination renewed. "We'll rescue her," he said. "We'll get her out of there, no matter what it takes."


### PR DESCRIPTION
Contributor: Marv2.0/ChaosDelivery#2855

Other notes:
- updated the readme.md to reflect the changes from yaml and the text description
- added characters Astrid, Gadrull, and Vadanna with reference to the Winterbeard's Sigil being in Auristar where The Mad Chronicler is heard of but unsure whether the directory for the characters are correct and scalable